### PR TITLE
ajout hooks de précommit via grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,6 +97,29 @@ module.exports = function(grunt) {
         ],
         tasks: ['dev']
       }
+    },
+
+    githooks: {
+      all: {
+        'pre-commit': 'test lint',
+      }
+    },
+
+    shell: {
+        atoum: {
+            options: {
+                stdout: true,
+                failOnError: true,
+            },
+            command: './bin/atoum'
+        },
+        coke: {
+            options: {
+                stdout: true,
+                failOnError: true,
+            },
+            command: './bin/coke'
+        }
     }
   });
   grunt.loadNpmTasks('grunt-contrib-concat');
@@ -108,7 +131,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-css-url-rewrite');
   grunt.loadNpmTasks('grunt-hash');
+  grunt.loadNpmTasks('grunt-githooks');
+  grunt.loadNpmTasks('grunt-shell');
 
+  grunt.registerTask('test', ['shell:atoum']);
+  grunt.registerTask('lint', ['shell:coke']);
   grunt.registerTask('dev', ['clean', 'copy', 'cssUrlRewrite', 'sass', 'concat', 'hash']);
   grunt.registerTask('default', ['dev', 'uglify', 'cssmin']);
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-hash": "~0.5.0",
-    "grunt-contrib-sass": "~0.7.1"
+    "grunt-contrib-sass": "~0.7.1",
+    "grunt-githooks": "~0.3.1",
+    "grunt-shell": "~0.6.4"
   }
 }


### PR DESCRIPTION
En effectuant un `grunt githooks` un hook de précommit
sera installé.

Ce hook effectuera une vérification du bon fonctionnement
des tests unitaires ainsi qu'une vérification du respect
des conventions de codage en PHP.
