### PR TITLE
Modification de la commande pour lancer grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Build des assets
 ----------------
 
 ```
-grunt
+./node_modules/.bin/grunt
 ```
 
 Pour les builder automatiquement à chaque modification :
 
 ```
-grunt watch
+./node_modules/.bin/grunt watch
 ```
 


### PR DESCRIPTION
En ajoutant grunt-cli dans le fichier package.json, on a maintenant un binaire de grunt disponible directement dans le projet dans `./node_modules/.bin/`.
