### PR TITLE
correction minification des assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,7 +142,8 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test', ['shell:atoum']);
   grunt.registerTask('lint', ['shell:coke']);
-  grunt.registerTask('dev', ['clean', 'copy', 'cssUrlRewrite', 'sass', 'concat', 'hash']);
-  grunt.registerTask('default', ['dev', 'uglify', 'cssmin']);
+  grunt.registerTask('common', ['clean', 'copy', 'cssUrlRewrite', 'sass', 'concat']);
+  grunt.registerTask('dev', ['common', 'hash']);
+  grunt.registerTask('default', ['common', 'uglify', 'cssmin', 'hash']);
 
 };


### PR DESCRIPTION
La copie des fichiers dans le dossier web/assets se fait
à l'étape hash, or dans la task par défaut les taches
uglyfyjs et cssmin étaient effectuées après cette copie.

La minification était donc effectuée sur le fichier dans
le dossier de cache, mais jamais reportée dans le dossier
web.

Pour éviter cela, on effectue bien l'étape hash à la fin
de la tache default.
