### PR TITLE
Correction application des filtres spécialités et certification en même temps

### DIFF
--- a/src/Afup/Barometre/Filter/SpecialityFilter.php
+++ b/src/Afup/Barometre/Filter/SpecialityFilter.php
@@ -43,8 +43,8 @@ class SpecialityFilter implements FilterInterface
         }, $specialities);
 
         $queryBuilder
-            ->leftJoin('response', 'response_speciality', 'rc', 'response.id = rc.response_id')
-            ->andWhere('rc.speciality_id IN(:specialities)')
+            ->leftJoin('response', 'response_speciality', 'rs', 'response.id = rs.response_id')
+            ->andWhere('rs.speciality_id IN(:specialities)')
             ->setParameter('specialities', $specialities, Connection::PARAM_INT_ARRAY);
     }
 


### PR DESCRIPTION
Les alias des jointures sur les tables certification et
spécialité étaient identiques. Une exception apparaissait
quand les deux filtres étaient appliqués en même temps.

On renomme donc l'un des alias pour corriger ce problème.
