### PR TITLE
Typo improvements

### DIFF
--- a/src/Afup/BarometreBundle/Resources/assets/sass/_bootstrap_variables.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/_bootstrap_variables.scss
@@ -1,6 +1,17 @@
 // Bootstrap overide:
 $brand-primary: $afup-blue;
 $font-family-title: "Glegoo", Helvetica, Arial, sans-serif;
+$font-size-base: 14px;
+
+// Navbar
 $navbar-height: 60px;
 $navbar-inverse-bg: $afup-blue;
 $navbar-inverse-link-color: lighten(#000, 93.5%);
+
+// Titles
+$font-size-h1: floor($font-size-base * 2.4); // ~36px
+$font-size-h2: floor($font-size-base * 2); // ~30px
+$font-size-h3: ceil($font-size-base * 1.5); // ~24px
+$font-size-h4: ceil($font-size-base * 1.2); // ~18px
+$font-size-h5: $font-size-base;
+$font-size-h6: ceil($font-size-base * 0.85); // ~12px

--- a/src/Afup/BarometreBundle/Resources/assets/sass/_variables.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/_variables.scss
@@ -3,5 +3,4 @@ $icon-font-path: "../fonts/";
 
 // Colors:
 $afup-blue: #4C6EAF;
-$dark-blue: #4e5a7d;
-$light-blue: #1EBDFF;
+$afup-blue-light: lighten($afup-blue, 33%);

--- a/src/Afup/BarometreBundle/Resources/assets/sass/ui/_typo.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/ui/_typo.scss
@@ -1,29 +1,12 @@
-h1, h2, h3, h4, h5, h6 {
+h1, h2, h3, h4, h5, h6, label {
     font-family: $font-family-title;
 }
 
 h1, h2 {
-  font-weight: bold;
-  margin: 10px 0px;
-  font-variant: small-caps;
+    @extend .page-header;
+    border-color: $afup-blue-light;
 }
 
-h1.page-header {
-  border-bottom: 3px solid #4e71b2;
-  font-size: 1.35em;
-  padding: 5px 0 5px 5px;
-  width: 100%;
-}
-
-h2 {
-  border-bottom: 2px solid #4e71b2;
-  font-size: 1.25em;
-  padding: 2px 0 2px 5px;
-  width: 45%;
-}
-
-p {
-  text-indent: 5%;
-  text-align: justify;
-  padding: 15px;
+hr {
+    border-color: $afup-blue-light;
 }

--- a/src/Afup/BarometreBundle/Resources/views/About/index.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/About/index.html.twig
@@ -3,7 +3,7 @@
 {% block title %}A propos du  Baromètre AFUP{% endblock %}
 
 {% block content %}
-    <h1 class="page-header">A propos du  Baromètre AFUP</h1>
+    <h1>A propos du  Baromètre AFUP</h1>
 
     <h2>Genèse du baromètre</h2>
     <p>

--- a/src/Afup/BarometreBundle/Resources/views/Default/index.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Default/index.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ report.label|trans }} | {{ parent() }}{% endblock %}
 
 {% block content %}
-    <h1 class="page-header">{{ report.label | trans }}</h1>
+    <h1>{{ report.label | trans }}</h1>
 
     {% block filters render(controller('AfupBarometreBundle:Form:index')) %}
 


### PR DESCRIPTION
CF: https://github.com/afup/barometre/issues/65

![capture decran 2014-02-15 a 14 22 01](https://f.cloud.github.com/assets/1846873/2177872/2ed1749e-9644-11e3-9195-168da6deb89c.png)

J'ai gardé : 
- Tout les titres soulignés
- Une police de titre un peu plus petite
- La couleur bleu (en plus light)

J'ai corrigé :
- Tout doit être aligné sur la même grille : pas de padding left sur les titre ou le texte.
- Bordures trop épaisses
- Camel case sur les titres

À discuter : 
- Les labels vous les préférez en Arial ou avec la police des titres ?
