### PR TITLE
mise à jour d'highchartTable en version 1.0.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "select2": "3.4.5",
     "bootstrap-sass-official": "v3.0.3.0",
     "select2-bootstrap3-css": "master",
-    "highchartTable": "~1.0.3",
+    "highchartTable": "~1.0.4",
     "jquery.tablesorter": "~2.14.5",
     "colorbrewer": "~1.0.0",
     "d3": "~2.10.3"


### PR DESCRIPTION
Voir https://github.com/highchartTable/jquery-highchartTable-plugin/pull/52 et https://github.com/afup/barometre/pull/85
