### PR TITLE
correction affichage du tooltip sur les départements

### DIFF
--- a/src/Afup/BarometreBundle/Resources/assets/js/map.js
+++ b/src/Afup/BarometreBundle/Resources/assets/js/map.js
@@ -4,7 +4,8 @@
 
     var tooltip = d3.select("body")
       .append("div")
-      .attr("class", "tooltip");
+      .attr("class", "tooltip")
+      .style("visibility", "hidden");
 
     function init() {
         var xy = d3.geo.albers()
@@ -50,8 +51,8 @@
             tooltip.text(d.properties.NOM_DEPT + " / " + value);
             return tooltip.style("visibility", "visible");
         })
-        .on("mousemove", function (event) {
-            return tooltip.style("top", (event.pageY - 10) + "px").style("left", (event.pageX + 10) + "px");
+        .on("mousemove", function () {
+            return tooltip.style("top", (d3.event.pageY - 10) + "px").style("left", (d3.event.pageX + 10) + "px");
         })
         .on("mouseout", function () {
             return tooltip.style("visibility", "hidden");


### PR DESCRIPTION
Le tooltip affichant les noms des départements et les salaires
était affiché en bas à gauche de la page.
En utilisant correctement l'évènement d3, celui-ci est bien placé.
