### PR TITLE
ajout de flèches pour afficher masquer l'input des filtres

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,7 @@ module.exports = function(grunt) {
           'src/Afup/BarometreBundle/Resources/assets/js/tablesorter.js',
           'src/Afup/BarometreBundle/Resources/assets/js/select2.js',
           'src/Afup/BarometreBundle/Resources/assets/js/charts.js',
+          'src/Afup/BarometreBundle/Resources/assets/js/filters.js',
           'src/Afup/BarometreBundle/Resources/assets/js/map.js'
         ],
         dest: 'app/cache/grunt/main.js'

--- a/src/Afup/BarometreBundle/Resources/assets/js/filters.js
+++ b/src/Afup/BarometreBundle/Resources/assets/js/filters.js
@@ -1,0 +1,11 @@
+$(document).ready(function () {
+    $('.filter-toggler', '.form-group').click(function (e) {
+        var parentGroup = $(this).parents('.form-group');
+        $('.form-row-content', parentGroup).toggle();
+        $('.glyphicon', parentGroup)
+            .toggleClass('glyphicon-chevron-down')
+            .toggleClass('glyphicon-chevron-up')
+        ;
+        e.preventDefault();
+    });
+});

--- a/src/Afup/BarometreBundle/Resources/assets/sass/_filters.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/_filters.scss
@@ -1,0 +1,7 @@
+.form-group .filter-toggler {
+  font-family: $font-family-title;
+  font-weight: bold;
+  margin: 0 0 5px;
+  color: #000;
+  text-decoration: none;
+}

--- a/src/Afup/BarometreBundle/Resources/assets/sass/main.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/main.scss
@@ -29,3 +29,4 @@
 @import "map";
 @import "filters-summary";
 @import "results";
+@import "filters";

--- a/src/Afup/BarometreBundle/Resources/views/Filters/index.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Filters/index.html.twig
@@ -7,5 +7,4 @@
         {{ form_row(child, { 'widget_attr': {'class' : 'hide'}}) }}
     {% endfor %}
 
-    {{ form_rest(form) }}
 {{ form_end(form) }}

--- a/src/Afup/BarometreBundle/Resources/views/Filters/theme.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Filters/theme.html.twig
@@ -7,9 +7,14 @@
 
 {% block form_row %}
     <div class="form-group">
-        {{ form_label(form) }}
+        <a href="#" class="filter-toggler">
+            {{ label|trans({}, translation_domain) }}
+            <i class="glyphicon {% if value is empty %}glyphicon-chevron-down{% else %}glyphicon-chevron-up{% endif %}"></i>
+        </a>
         {{ form_errors(form) }}
-        {{ form_widget(form) }}
+        <div class="form-row-content" {% if value is empty %}style="display: none"{% endif %}>
+            {{ form_widget(form) }}
+        </div>
     </div>
 {% endblock %}
 
@@ -31,3 +36,16 @@
     </div>
 {% endblock %}
 
+
+{% block salary_row %}
+    <div class="form-group">
+        <a href="#" class="filter-toggler">
+            {{ label|trans({}, translation_domain) }}
+            <i class="glyphicon {% if form.min.vars.value is empty and form.max.vars.value is empty %}glyphicon-chevron-down{% else %}glyphicon-chevron-up{% endif %}"></i>
+        </a>
+        {{ form_errors(form) }}
+        <div class="form-row-content" {% if form.min.vars.value is empty and form.max.vars.value is empty %}style="display: none"{% endif %}>
+            {{ form_widget(form) }}
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Ajout de flèches à droite des labels de filtres pour afficher/masquer
les inputs de filtres. Ceux-ci sont masqués par défaut.

Cela permet d'avoir le bouton de submit au dessus de la ligne de
flottaison.

![distribution-des-tailles-d-entreprises-barom-tre-afup 2014-04-06 17-40-51](https://cloud.githubusercontent.com/assets/320372/2625613/f0c04268-bda1-11e3-8dbc-6c29cbaa4a34.png)
