### PR TITLE
correction affichage message pas de données sur raport géo

### DIFF
--- a/src/Afup/Barometre/Report/CompanyDepartmentReport.php
+++ b/src/Afup/Barometre/Report/CompanyDepartmentReport.php
@@ -20,7 +20,7 @@ class CompanyDepartmentReport extends AbstractReport
             ->setParameter(':minResult', $this->minResult)
             ->addGroupBy('response.companyDepartment');
 
-        $this->data = $this->queryBuilder->execute();
+        $this->data = $this->queryBuilder->execute()->fetchAll();
     }
 
     /**


### PR DESCRIPTION
Si on filtrait jusqu'a ne pas avoir de données, la page
répartition géographique affichait un tableau et une carte
vide au lieu d'afficher un message indiquant qu'il n'y a
pas de données.

Cela car le count était effectué sur le statement, qui
renvoyait 1 même si il n'y avait pas de données.

Fixes #113
