### PR TITLE
mise en cache des réponses

### DIFF
--- a/src/Afup/BarometreBundle/DependencyInjection/AfupBarometreExtension.php
+++ b/src/Afup/BarometreBundle/DependencyInjection/AfupBarometreExtension.php
@@ -28,6 +28,7 @@ class AfupBarometreExtension extends Extension
         $loader->load('filters.xml');
         $loader->load('reports.xml');
         $loader->load('menu.xml');
+        $loader->load('http_cache.xml');
 
         $container->setParameter('afup.barometre.parameters.report.min_result', $config['min_result']);
     }

--- a/src/Afup/BarometreBundle/EventListener/ResponseListener.php
+++ b/src/Afup/BarometreBundle/EventListener/ResponseListener.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Afup\BarometreBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class ResponseListener
+{
+    /**
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $event->getResponse()->setSharedMaxAge(31536000);
+    }
+}

--- a/src/Afup/BarometreBundle/Resources/config/http_cache.xml
+++ b/src/Afup/BarometreBundle/Resources/config/http_cache.xml
@@ -1,0 +1,12 @@
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+                               http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="barometre.filter_response_listener" class="Afup\BarometreBundle\EventListener\ResponseListener">
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+        </service>
+    </services>
+
+</container>

--- a/web/app.php
+++ b/web/app.php
@@ -15,14 +15,14 @@ $apcLoader->register(true);
 */
 
 require_once __DIR__.'/../app/AppKernel.php';
-//require_once __DIR__.'/../app/AppCache.php';
+require_once __DIR__.'/../app/AppCache.php';
 
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();
-//$kernel = new AppCache($kernel);
+$kernel = new AppCache($kernel);
 
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
-//Request::enableHttpMethodParameterOverride();
+Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
En prod les réponses sont stockées dans

```
app/cache/prod/http_cache
```

Cela permet de passer de 71ms à 1/2ms sur la page "a propos"
et de 139ms à 1/2ms sur la page "distribution des tailles d'entreprise".
Cela évite de refaire des requêtes en base pour des rapports qui seront
identiques.

Pour invalider le cache il faut faire un

```
php app/console cache:clear --env=prod
```

(qui est effectué lors du déploiement).
