### PR TITLE
On évite de charger la liste des départements sur toutes les pages

### DIFF
--- a/src/Afup/BarometreBundle/Resources/assets/js/map.js
+++ b/src/Afup/BarometreBundle/Resources/assets/js/map.js
@@ -8,6 +8,11 @@
       .style("visibility", "hidden");
 
     function init() {
+
+        if (1 !== $('#map').length) {
+            return;
+        }
+
         var xy = d3.geo.albers()
             .origin([2.6, 46.5])
             .parallels([44, 49])


### PR DESCRIPTION
La liste des départements, utilisée sur la répartition géographique
était chargée sur toutes les pages. Cela causait un appel ajax sur
toutes les pages.

Elle est maintenant chargée seulement sur la répartition géographique.
