### PR TITLE
on évite de faire un appel pour charger la font

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -11,7 +11,6 @@
         {% endblock meta %}
 
         {% block stylesheets %}
-        <link href='http://fonts.googleapis.com/css?family=Glegoo' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="{{ compiled_css_file }}" />
         {% endblock stylesheets %}
         {% block ga '' %}

--- a/src/Afup/BarometreBundle/Resources/assets/sass/_global.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/_global.scss
@@ -1,3 +1,10 @@
 body {
     padding-top: $navbar-height;
 }
+
+@font-face {
+  font-family: 'Glegoo';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Glegoo'), local('Glegoo-Regular'), url(http://fonts.gstatic.com/s/glegoo/v3/8x8S7gQMbbduiGv8gbUJ0Q.woff) format('woff');
+}


### PR DESCRIPTION
au lieu de faire un appel pour récupérer la css qui
va charger la font, on l'intègre directement à la
css générée par sass.
