### PR TITLE
suppression vérification accès à app_dev

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -7,16 +7,6 @@ use Symfony\Component\Debug\Debug;
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
 //umask(0000);
 
-// This check prevents access to debug front controllers that are deployed by accident to production servers.
-// Feel free to remove this, extend it, or make something more sophisticated.
-if (isset($_SERVER['HTTP_CLIENT_IP'])
-    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
-) {
-    header('HTTP/1.0 403 Forbidden');
-    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
-}
-
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 Debug::enable();
 


### PR DESCRIPTION
Les fichiers _dev sont supprimés lors du
déploiement. Supprimer la vérification permet
de simplifier l'accès en dev.
