### PR TITLE
Ajout d'une deuxième campagne aux données de test

### DIFF
--- a/src/Afup/BarometreBundle/Resources/test/response.yml
+++ b/src/Afup/BarometreBundle/Resources/test/response.yml
@@ -1,12 +1,16 @@
 Afup\BarometreBundle\Entity\Campaign:
     campaign1:
         name: "2013"
-        startDate: <dateTime()>
-        endDate: <dateTime()>
+        startDate: <dateTimeBetween('2013-01-01', '2013-12-31')>
+        endDate: <dateTimeBetween($startDate, '2013-12-31')>
+    campaign2:
+        name: "2014"
+        startDate: <dateTimeBetween('2014-01-01', '2014-10-06')>
+        endDate: <dateTimeBetween($startDate, '2014-10-06')>
 
 Afup\BarometreBundle\Entity\Response:
-    response{1..1200}:
-        campaign: @campaign1
+    response{1..2600}:
+        campaign: 70%? @campaign1 : @campaign2
         grossAnnualSalary: <numberBetween(20000, 45000)>
         variableAnnualSalary: <numberBetween(0, 4500)>
         annualSalary: <numberBetween(20000, 45000)>


### PR DESCRIPTION
Il y a maitenant deux campagnes, 2013 et 2014.
On augmente le nombre de réponses. 70% d'entre-elles sont sur
la première campagne.
