### PR TITLE
Ajout d'un filtre sur la campagne

### DIFF
--- a/src/Afup/Barometre/Filter/CampaignFilter.php
+++ b/src/Afup/Barometre/Filter/CampaignFilter.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Afup\Barometre\Filter;
+
+use Doctrine\ORM\EntityRepository;
+use Symfony\Component\Form\FormBuilderInterface;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class CampaignFilter implements FilterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder)
+    {
+        $builder->add($this->getName(), 'entity', [
+            'label'    => 'filter.campaign',
+            'class'    => 'Afup\BarometreBundle\Entity\Campaign',
+            'attr'     => ['class' => 'select2'],
+            'multiple' => true,
+            'required' => false,
+            'query_builder' => function (EntityRepository $repository) {
+                return $repository
+                    ->createQueryBuilder('campaign')
+                    ->orderBy('campaign.name', 'ASC');
+            }
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildQuery(QueryBuilder $queryBuilder, array $values = array())
+    {
+        if (!array_key_exists($this->getName(), $values) || 0 === count($values[$this->getName()])) {
+            return;
+        }
+
+        $campaigns = array_map(function ($item) {
+            return $item->getId();
+        }, $values[$this->getName()]->toArray());
+
+        $queryBuilder
+            ->andWhere($queryBuilder->expr()->in('response.campaign_id', $campaigns));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertValuesToLabels($value)
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'campaign';
+    }
+
+    /**
+     * Filter weight
+     *
+     * @return int
+     */
+    public function getWeight()
+    {
+        return -1;
+    }
+}

--- a/src/Afup/BarometreBundle/Entity/Campaign.php
+++ b/src/Afup/BarometreBundle/Entity/Campaign.php
@@ -5,7 +5,7 @@ namespace Afup\BarometreBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Afup\BarometreBundle\Entity\CampaignRepository")
  * @ORM\Table(name="campaign")
  */
 class Campaign
@@ -100,5 +100,13 @@ class Campaign
     public function getEndDate()
     {
         return $this->endDate;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __toString()
+    {
+        return $this->getName();
     }
 }

--- a/src/Afup/BarometreBundle/Entity/CampaignRepository.php
+++ b/src/Afup/BarometreBundle/Entity/CampaignRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Afup\BarometreBundle\Entity;
+
+use Doctrine\ORM\EntityRepository;
+
+class CampaignRepository extends EntityRepository
+{
+    /**
+     * @return Campaign|null
+     */
+    public function getLast()
+    {
+        return $this->findOneBy(array(), array('endDate' => 'desc'));
+    }
+}

--- a/src/Afup/BarometreBundle/Filtering/DefaultContextFactory.php
+++ b/src/Afup/BarometreBundle/Filtering/DefaultContextFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Afup\BarometreBundle\Filtering;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Afup\BarometreBundle\Entity\CampaignRepository;
+
+class DefaultContextFactory extends ContextFactory
+{
+    /**
+     * @var CampaignRepository
+     */
+    protected $campaignRepository;
+
+    /**
+     * @param CampaignRepository $campaignRepository
+     */
+    public function __construct(CampaignRepository $campaignRepository)
+    {
+        $this->campaignRepository = $campaignRepository;
+    }
+
+    /**
+     * @param RequestStack $requestStack
+     *
+     * @return Context
+     */
+    public function createFromRequestStack(RequestStack $requestStack)
+    {
+        $context = parent::createFromRequestStack($requestStack);
+
+        if (0 === count($context->getParameters())) {
+            $lastCampaign = $this->campaignRepository->getLast();
+            if (null !== $lastCampaign) {
+                $context->setParameter('campaign', array($lastCampaign->getId()));
+            }
+        }
+
+        return $context;
+    }
+}

--- a/src/Afup/BarometreBundle/Resources/config/filters.xml
+++ b/src/Afup/BarometreBundle/Resources/config/filters.xml
@@ -14,6 +14,7 @@
         <parameter key="afup.barometre.filter.salary_satisfaction.class">Afup\Barometre\Filter\SalarySatisfactionFilter</parameter>
         <parameter key="afup.barometre.filter.job_title.class">Afup\Barometre\Filter\JobTitleFilter</parameter>
         <parameter key="afup.barometre.filter.status.class">Afup\Barometre\Filter\StatusFilter</parameter>
+        <parameter key="afup.barometre.filter.campaign.class">Afup\Barometre\Filter\CampaignFilter</parameter>
     </parameters>
 
     <services>
@@ -60,6 +61,10 @@
 
         <service id="afup.barometre.filter.job_title" class="%afup.barometre.filter.job_title.class%">
             <argument type="service" id="afup.barometre.enums.job_title" />
+            <tag name="barometre.filter" alias="job_title" />
+        </service>
+
+        <service id="afup.barometre.filter.campaign" class="%afup.barometre.filter.campaign.class%">
             <tag name="barometre.filter" alias="job_title" />
         </service>
 

--- a/src/Afup/BarometreBundle/Resources/config/menu.xml
+++ b/src/Afup/BarometreBundle/Resources/config/menu.xml
@@ -10,7 +10,7 @@
         <service id="afup.barometre.menu.menu_builder" class="%afup.barometre.menu.menu_builder.class%">
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="afup.barometre.report_collection" />
-            <argument type="service" id="afup.barometre.context" />
+            <argument type="service" id="afup.barometre.default_context" />
         </service>
 
         <service id="afup.barometre.menu"

--- a/src/Afup/BarometreBundle/Resources/config/services.xml
+++ b/src/Afup/BarometreBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="afup.barometre.campaign.response_factory.class">Afup\BarometreBundle\Campaign\ResponseFactory</parameter>
         <parameter key="afup.barometre.context.class">Afup\BarometreBundle\Filtering\Context</parameter>
         <parameter key="afup.barometre.context_factory.class">Afup\BarometreBundle\Filtering\ContextFactory</parameter>
+        <parameter key="afup.barometre.default_context_factory.class">Afup\BarometreBundle\Filtering\DefaultContextFactory</parameter>
         <parameter key="afup.barometre.query_builder_factory.class">Afup\BarometreBundle\Filtering\QueryBuilderFactory</parameter>
         <parameter key="number_formatter.class">NumberFormatter</parameter>
     </parameters>
@@ -19,6 +20,11 @@
             <argument type="service" id="request_stack" />
         </service>
 
+        <service
+                id="afup.barometre.default_context"
+                factory-service="afup.barometre.default_context_factory"
+                parent="afup.barometre.context" />
+
         <service id="afup.barometre.query_builder_factory" class="%afup.barometre.query_builder_factory.class%">
             <argument type="service" id="doctrine.dbal.default_connection" />
             <argument type="service" id="afup.barometre.context" />
@@ -26,6 +32,10 @@
         </service>
 
         <service id="afup.barometre.context_factory" class="%afup.barometre.context_factory.class%" />
+
+        <service id="afup.barometre.default_context_factory" class="%afup.barometre.default_context_factory.class%" >
+            <argument type="service" id="afup.barometre.repository.campaign_repository" />
+        </service>
 
         <service id="afup.barometre.campaign.importer" class="%afup.barometre.campaign.importer.class%">
             <argument type="service" id="doctrine.orm.entity_manager" />
@@ -47,6 +57,13 @@
         <service id="number_formatter" class="%number_formatter.class%">
             <argument>fr</argument>
             <argument>1</argument>
+        </service>
+
+        <service id="afup.barometre.repository.campaign_repository"
+                 class="Doctrine\ORM\EntityRepository"
+                 factory-service="doctrine.orm.entity_manager"
+                 factory-method="getRepository">
+            <argument>Afup\BarometreBundle\Entity\Campaign</argument>
         </service>
 
         <service id="afup.barometre.repository.certification_repository"

--- a/src/Afup/BarometreBundle/Resources/translations/messages.fr.xliff
+++ b/src/Afup/BarometreBundle/Resources/translations/messages.fr.xliff
@@ -34,6 +34,10 @@
                 <source>filter.experience</source>
                 <target>Expérience</target>
             </trans-unit>
+            <trans-unit id="filter.campaign">
+                <source>filter.campaign</source>
+                <target>Année</target>
+            </trans-unit>
             <trans-unit id="filter.salary_satisfaction">
                 <source>filter.salary_satisfaction</source>
                 <target>Satisfaction de la rémunération</target>


### PR DESCRIPTION
Un sélecteur des années apparait maintenant dans la liste des filtres.

Par défaut, le menu renvoie vers les pages avec un filtre sur la dernière
campagne.

Il est possible de filtrer sur l'année précédente ou sur toutes les
campagnes.

![distribution_des_salaires_barometre_afup_-_2014-10-04_13 12 52](https://cloud.githubusercontent.com/assets/320372/4515343/c309f07c-4bb7-11e4-9d52-c9c85472bdfc.png)
