### PR TITLE
gestion du format d'import 2014

### DIFF
--- a/src/Afup/BarometreBundle/Campaign/Format/FormatFactory.php
+++ b/src/Afup/BarometreBundle/Campaign/Format/FormatFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Afup\BarometreBundle\Campaign\Format;
+
+class FormatFactory
+{
+    /**
+     * @param string $code
+     *
+     * @return FormatInterface
+     */
+    public function createFromCode($code)
+    {
+        $class = '\Afup\BarometreBundle\Campaign\Format\Formats\Format' . $code;
+        if (!class_exists($class)) {
+            throw new \InvalidArgumentException(sprintf('Code %s invalid', $code));
+        }
+
+        return new $class;
+    }
+}

--- a/src/Afup/BarometreBundle/Campaign/Format/FormatInterface.php
+++ b/src/Afup/BarometreBundle/Campaign/Format/FormatInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Afup\BarometreBundle\Campaign\Format;
+
+interface FormatInterface
+{
+    /**
+     * @return array
+     */
+    public function getColumns();
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    public function alterData(array $data);
+}

--- a/src/Afup/BarometreBundle/Campaign/Format/Formats/Format2013.php
+++ b/src/Afup/BarometreBundle/Campaign/Format/Formats/Format2013.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace Afup\BarometreBundle\Campaign;
+namespace Afup\BarometreBundle\Campaign\Format\Formats;
 
-class ResponseFormat
+use Afup\BarometreBundle\Campaign\Format\FormatInterface;
+
+class Format2013 implements FormatInterface
 {
     /**
      * @return array
@@ -36,5 +38,19 @@ class ResponseFormat
             "formation_subject",
             "formation_impact",
         );
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    public function alterData(array $data)
+    {
+        array_walk($data, function (&$item) {
+            $item = utf8_encode($item);
+        });
+
+        return $data;
     }
 }

--- a/src/Afup/BarometreBundle/Campaign/Format/Formats/Format2014.php
+++ b/src/Afup/BarometreBundle/Campaign/Format/Formats/Format2014.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Afup\BarometreBundle\Campaign\Format\Formats;
+
+use Afup\BarometreBundle\Campaign\Format\FormatInterface;
+use Afup\BarometreBundle\Enums\ExperienceEnums;
+
+class Format2014 implements FormatInterface
+{
+    /**
+     * @return array
+     */
+    public function getColumns()
+    {
+        return array(
+            '',
+            "gross_annual_salary",
+            "variable_annual_salary",
+            "salary_satisfaction",
+            "initial_training",
+            'status',
+            "job_title",
+            "experience",
+            "company_department",
+            "company_type",
+            "company_size",
+            "job_interest",
+            "speciality",
+            "php_version",
+            "has_certification",
+            "certification_list",
+            "php_strength",
+            "has_formation",
+            "formation_subject",
+            "formation_impact",
+            "email",
+            "",
+        );
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    public function alterData(array $data)
+    {
+        if ($data['experience'] == '2 à 5 ans') {
+            $data['experience'] = "3 à 5 ans";
+        } elseif ($data['experience'] == '5 à 10 ans') {
+            $data['experience'] = "6 à 10 ans";
+        }
+
+        $data['annual_salary'] = $data['gross_annual_salary'] + $data['variable_annual_salary'];
+
+        return $data;
+    }
+}

--- a/src/Afup/BarometreBundle/Command/BarometreImportCommand.php
+++ b/src/Afup/BarometreBundle/Command/BarometreImportCommand.php
@@ -2,10 +2,12 @@
 
 namespace Afup\BarometreBundle\Command;
 
+use Afup\BarometreBundle\Campaign\Format\FormatFactory;
 use Afup\BarometreBundle\Campaign\Importer\CampaignImporter;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class BarometreImportCommand extends ContainerAwareCommand
@@ -15,6 +17,7 @@ class BarometreImportCommand extends ContainerAwareCommand
         $this
             ->setName("barometre:imports")
             ->setDescription("Importe une nouvelle campagne")
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Format du fichier ("2013" ou "2013")')
             ->addArgument('name', InputArgument::REQUIRED, 'Nom de la campagne')
             ->addArgument('startDate', InputArgument::REQUIRED, 'Date de début de la campagne (format: dd/mm/yyyy)')
             ->addArgument('endDate', InputArgument::REQUIRED, 'Date de fin de la campagne (format: dd/mm/yyyy)')
@@ -34,8 +37,12 @@ class BarometreImportCommand extends ContainerAwareCommand
         $endDate    = $input->getArgument('endDate');
         $filename   = $input->getArgument('filename');
 
+        $formatFactory = new FormatFactory();
+        $format = $formatFactory->createFromCode($input->getOption('format'));
+
         $importer = $this->getCampaignImporter();
         $importer->import(
+            $format,
             $name,
             \DateTime::createFromFormat('d/m/Y', $startDate),
             \DateTime::createFromFormat('d/m/Y', $endDate),


### PR DESCRIPTION
Ajout d'une option --format à la commande `php app/console barometre:imports`.

L'import se faire maintenant comme ceci :

```
php app/console barometre:imports --format=2014 "2014" "01/01/2014" "31/12/2014" reponses_2014.csv
```
