### PR TITLE
Amélioration affichage rapport satisfaction de la rémunération

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 /node_modules/
 /web/assets/
 /src/Afup/BarometreBundle/Resources/assets/sass/vendor/
+/src/Afup/BarometreBundle/Resources/assets/sass/generated/
 /.sass-cache/

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,5 +1,6 @@
 exclude:
   - 'src/Afup/BarometreBundle/Resources/assets/sass/vendor/*'
+  - 'src/Afup/BarometreBundle/Resources/assets/sass/generated/*'
 
 linters:
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,6 @@ module.exports = function(grunt) {
         files: [
           {expand: true, cwd: 'bower_components/select2/', src: ['**.png'], dest: 'web/assets/images/select2/', filter: 'isFile'},
           {expand: true, cwd: 'bower_components/select2/', src: ['**.gif'], dest: 'web/assets/images/select2/', filter: 'isFile'},
-          {expand: true, cwd: 'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/', src: ['*'], dest: 'web/assets/fonts/', filter: 'isFile'},
           {expand: true, cwd: 'bower_components/bootstrap-sass-official/vendor/assets/stylesheets/', src: ['**'], dest: 'src/Afup/BarometreBundle/Resources/assets/sass/vendor/'},
           {expand: true, cwd: 'bower_components/select2/', src: ['select2-bootstrap.scss'], dest: 'src/Afup/BarometreBundle/Resources/assets/sass/vendor/'},
           {expand: false, src: 'bower_components/jquery.tablesorter/css/theme.bootstrap.css', dest: 'src/Afup/BarometreBundle/Resources/assets/sass/vendor/tablesorter.theme.bootstrap.scss'},
@@ -33,6 +32,53 @@ module.exports = function(grunt) {
           dest: 'src/Afup/BarometreBundle/Resources/assets/sass/vendor/select2-bootstrap.scss',
       }
     },
+
+    webfont_svg_extractor: {
+        glyphicon: {
+            options: {
+                fontPath: "bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.svg",
+                cssPath: "bower_components/bootstrap/dist/css/bootstrap.css",
+                outputDir: "app/cache/grunt/font/",
+                preset: "glyphicon",
+                icons: [
+                    "remove",
+                    "chevron-up",
+                    "chevron-down"
+                ]
+            }
+        },
+        fontawesome: {
+            options: {
+                fontPath: "bower_components/fontawesome/fonts/fontawesome-webfont.svg",
+                cssPath: "bower_components/fontawesome/css/font-awesome.css",
+                outputDir: "app/cache/grunt/font/",
+                preset: "fontawesome",
+                icons: [
+                    "smile-o",
+                    "frown-o"
+                ]
+            }
+        }
+    },
+
+    webfont: {
+        icons: {
+            src: 'app/cache/grunt/font/*.svg',
+            dest: 'web/assets/fonts',
+            destCss: 'src/Afup/BarometreBundle/Resources/assets/sass/generated',
+            options: {
+                templateOptions: {
+                    baseClass: 'icon',
+                    classPrefix: 'icon-'
+                },
+                relativeFontPath: '/assets/fonts/',
+                htmlDemo: false,
+                engine: 'node',
+                stylesheet: 'scss'
+            }
+        }
+    },
+
 
     sass: {
        dist: {
@@ -187,10 +233,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-scss-lint');
+  grunt.loadNpmTasks('grunt-webfont');
+  grunt.loadNpmTasks('grunt-webfont-svg-extractor');
 
   grunt.registerTask('test', ['shell:atoum']);
   grunt.registerTask('lint', ['shell:coke', 'jshint', 'scsslint']);
-  grunt.registerTask('common', ['clean', 'copy', 'cssUrlRewrite', 'sass', 'concat']);
+  grunt.registerTask('common', ['clean', 'copy', 'cssUrlRewrite', 'webfont_svg_extractor', 'webfont', 'sass', 'concat']);
   grunt.registerTask('dev', ['common', 'hash']);
   grunt.registerTask('default', ['common', 'uglify', 'cssmin', 'hash']);
 

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,8 @@
     "highchartTable": "~1.0.4",
     "jquery.tablesorter": "~2.14.5",
     "colorbrewer": "~1.0.0",
-    "d3": "~2.10.3"
+    "d3": "~2.10.3",
+    "bootstrap": "v3.2.0",
+    "fontawesome": "v4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "grunt-githooks": "~0.3.1",
     "grunt-shell": "~0.6.4",
     "grunt-contrib-jshint": "~0.8.0",
-    "grunt-scss-lint": "~0.3.2"
+    "grunt-scss-lint": "~0.3.2",
+    "grunt-webfont": "~0.4.8",
+    "grunt-webfont-svg-extractor": "0.0.2"
   }
 }

--- a/src/Afup/BarometreBundle/Resources/assets/js/charts.js
+++ b/src/Afup/BarometreBundle/Resources/assets/js/charts.js
@@ -1,6 +1,26 @@
 $(document).ready(function () {
+
     $('table.highchart')
         .bind('highchartTable.beforeRender', function (event, highChartConfig) {
+
+            if ($(this).hasClass('highchart-emoticon')) {
+                var icons = $(this).data('icons');
+
+                highChartConfig.plotOptions.series = {
+                    dataLabels: {
+                        useHTML: true,
+                        formatter : function () {
+                            var defaultDatalabel = '<b>' + this.point.name + '</b> : ' + this.percentage.toFixed(2) + '%';
+                            if (typeof icons[this.point.name] === 'undefined') {
+                                return defaultDatalabel;
+                            }
+                            var infos = icons[this.point.name];
+                            return '<i class="icon ' + infos.class + '" style="font-size: ' + infos.size + '"></i> ' + defaultDatalabel;
+                        }
+                    }
+                };
+            }
+
             highChartConfig.colors[0] = '#4C6EAF';
             var align = $(this).data('graph-xaxis-labels-align');
             if (align !== undefined) {

--- a/src/Afup/BarometreBundle/Resources/assets/js/tablesorter.js
+++ b/src/Afup/BarometreBundle/Resources/assets/js/tablesorter.js
@@ -8,9 +8,9 @@ $(document).ready(function () {
         footerRow  : '',
         footerCells: '',
         icons      : '', // add "icon-white" to make them white; this icon class is added to the <i> in the header
-        sortNone   : 'icon-unsorted glyphicon glyphicon-chevron-up',
-        sortAsc    : 'icon-sorted glyphicon glyphicon-chevron-up ',     // includes classes for Bootstrap v2 & v3
-        sortDesc   : 'icon-sorted glyphicon glyphicon-chevron-down ', // includes classes for Bootstrap v2 & v3
+        sortNone   : 'icon-unsorted icon icon-chevron-up',
+        sortAsc    : 'icon-sorted icon icon-chevron-up ',     // includes classes for Bootstrap v2 & v3
+        sortDesc   : 'icon-sorted icon icon-chevron-down ', // includes classes for Bootstrap v2 & v3
         active     : '', // applied when column is sorted
         hover      : '', // use custom css here - bootstrap class may not override it
         filterRow  : '', // filter row class

--- a/src/Afup/BarometreBundle/Resources/assets/sass/_bootstrap.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/_bootstrap.scss
@@ -16,7 +16,6 @@
 
 // Components
 @import "vendor/bootstrap/component-animations";
-@import "vendor/bootstrap/glyphicons";
 @import "vendor/bootstrap/navs";
 @import "vendor/bootstrap/navbar";
 @import "vendor/bootstrap/close";

--- a/src/Afup/BarometreBundle/Resources/assets/sass/_select2.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/_select2.scss
@@ -13,8 +13,8 @@
 }
 
 .select2-search-choice-close {
-  @extend .glyphicon;
-  @extend .glyphicon-remove;
+  @extend .icon;
+  @extend .icon-remove;
   background: none;
   color: #fff;
   font-size: 11px;

--- a/src/Afup/BarometreBundle/Resources/assets/sass/main.scss
+++ b/src/Afup/BarometreBundle/Resources/assets/sass/main.scss
@@ -12,6 +12,7 @@
 // Colorbrewer
 @import "vendor/colorbrewer";
 
+@import "generated/icons";
 
 // Barometre
 @import "global";

--- a/src/Afup/BarometreBundle/Resources/views/Filters/theme.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Filters/theme.html.twig
@@ -9,7 +9,7 @@
     <div class="form-group">
         <a href="#" class="filter-toggler">
             {{ label|trans({}, translation_domain) }}
-            <i class="glyphicon {% if value is empty %}glyphicon-chevron-down{% else %}glyphicon-chevron-up{% endif %}"></i>
+            <i class="icon {% if value is empty %}icon-chevron-down{% else %}icon-chevron-up{% endif %}"></i>
         </a>
         {{ form_errors(form) }}
         <div class="form-row-content" {% if value is empty %}style="display: none"{% endif %}>

--- a/src/Afup/BarometreBundle/Resources/views/Report/salary_satisfaction.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Report/salary_satisfaction.html.twig
@@ -1,9 +1,18 @@
-<table class="highchart highchart-align-xaxis-left-labels table table-striped"
+{% set icons =  {
+    "Très insatisfait": { class: 'icon-frown-o', size: '30px', color: "#550000"},
+    "Insatisfait": { class: 'icon-frown-o', size: '20px', color: "#b73030"},
+    "Sans opinion": { color: "#999999" },
+    "Satisfait": { class: 'icon-smile-o', size: '20px', color: "#259433"},
+    "Très satisfait": { class: 'icon-smile-o', size: '30px', color: "#008110"}
+} %}
+
+<table class="highchart highchart-emoticon highchart-align-xaxis-left-labels table table-striped"
        data-graph-datalabels-enabled="1"
        data-graph-container-before="1"
        data-graph-type="pie"
        data-graph-legend-disabled="1"
        data-graph-inverted="1"
+       data-icons="{{ icons|json_encode }}"
        data-graph-xaxis-labels-align="right">
     <thead>
     <tr>
@@ -13,9 +22,14 @@
     </thead>
     <tbody>
     {% for row in results %}
-        <tr>
-            <td>{{ row.salarySatisfaction|enum_label('salary_satisfaction') }}</td>
-            <td data-graph-name="{{ row.salarySatisfaction|enum_label('salary_satisfaction') }}" class="text-right">{{ row.nbResponse }}</td>
+        <tr {% if icons[row.salarySatisfaction|enum_label('salary_satisfaction')].color is defined %} style="color: {{ icons[row.salarySatisfaction|enum_label('salary_satisfaction')].color }}"{% endif %}>
+            <td>
+                {% if icons[row.salarySatisfaction|enum_label('salary_satisfaction')].class is defined %}
+                    <i class="icon {{ icons[row.salarySatisfaction|enum_label('salary_satisfaction')].class }}"></i>
+                {% endif %}
+                {{ row.salarySatisfaction|enum_label('salary_satisfaction') }}
+            </td>
+            <td {% if row.salarySatisfaction == 3 %}data-graph-item-highlight="1"{% endif %} {% if icons[row.salarySatisfaction|enum_label('salary_satisfaction')].color %}data-graph-item-color="{{ icons[row.salarySatisfaction|enum_label('salary_satisfaction')].color }}"{% endif %} data-graph-name='{{ row.salarySatisfaction|enum_label('salary_satisfaction') }}' data-icon-class="fa fa-smile-o" class="text-right">{{ row.nbResponse }}</td>
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
- Ajout icone pour représenter les différentes satisfactions.
- Les couleurs ne changent plus selon l'ordre des satisfactions

![satisfaction de la remuneration barometre afup](https://cloud.githubusercontent.com/assets/320372/4606750/f8f27c7c-522e-11e4-8eb9-29d145b12bf3.png)

Avant, les couleurs changeaient selon l'ordre des satisfactions :
![satisfaction de la remuneration barometre afup_ssii_avant](https://cloud.githubusercontent.com/assets/320372/4606752/147888a6-522f-11e4-9910-d207e4e8614b.png)
![satisfaction de la remuneration barometre afup_presse_avant](https://cloud.githubusercontent.com/assets/320372/4606753/1478cce4-522f-11e4-818f-c3206465520f.png)

Maintenant elles ne changent plus :
![satisfaction de la remuneration barometre afup_ssii_apres](https://cloud.githubusercontent.com/assets/320372/4606755/1fd6751e-522f-11e4-9569-5eba55826b39.png)
![satisfaction de la remuneration barometre afup_prese_apres](https://cloud.githubusercontent.com/assets/320372/4606754/1fcfcd40-522f-11e4-9719-f70004248c91.png)

Ainsi les comparatifs sont plus lisibles.

Pour insérer les icones, on passe par une icone de fontawesome.

Afin de ne pas avoir plusieurs font à charger (à la fois bootstrap et fontawesome),
on ne récupère que les icones utilisées dans chacune des fonts.

Ainsi les font moins lourdes à charger qu'avant :

Avant : 

```
-rw-r--r-- 1 root root  20K oct.  12 16:07 glyphicons-halflings-regular.eot
-rw-r--r-- 1 root root  62K oct.  12 16:07 glyphicons-halflings-regular.svg
-rw-r--r-- 1 root root  41K oct.  12 16:07 glyphicons-halflings-regular.ttf
-rw-r--r-- 1 root root  23K oct.  12 16:07 glyphicons-halflings-regular.woff
```

Après : 

```
-rw-r--r-- 1 root root 2,0K oct.  12 16:07 icons-b91a787410df2a225f64c96f77eda8d7.eot
-rw-r--r-- 1 root root 6,0K oct.  12 16:07 icons-b91a787410df2a225f64c96f77eda8d7.svg
-rw-r--r-- 1 root root 1,9K oct.  12 16:07 icons-b91a787410df2a225f64c96f77eda8d7.ttf
-rw-r--r-- 1 root root 1,2K oct.  12 16:07 icons-b91a787410df2a225f64c96f77eda8d7.woff
```

(au passage, le nom du fichier est maintenant en fonction de son contenu).

Et il y a moins de sélecteurs générés : 

Avant :
![csstreemap_-_2014-10-12_18 38 15](https://cloud.githubusercontent.com/assets/320372/4606757/52d0609c-522f-11e4-8129-afc1d677fc3e.png)

Après:
![csstreemap_-_2014-10-12_18 38 44](https://cloud.githubusercontent.com/assets/320372/4606759/58eb160c-522f-11e4-9485-a1d213190167.png)
