### PR TITLE
Désactivation de select2 sur les tablettes et téléphones

### DIFF
--- a/src/Afup/BarometreBundle/Resources/assets/js/select2.js
+++ b/src/Afup/BarometreBundle/Resources/assets/js/select2.js
@@ -1,4 +1,7 @@
 $(document).ready(function () {
+    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+        return;
+    }
     $(".select2").select2({
         closeOnSelect: false,
         placeholder: "Choisir une valeur"


### PR DESCRIPTION
Les filtres avec select2 sont très peu utilisables sur une interface tactile.
Mieux vaux utiliser les sélecteurs natifs.

Avant : 
![screenshot_2014-10-13-23-58-06](https://cloud.githubusercontent.com/assets/320372/4620912/822d3838-5324-11e4-8b3e-0b3947e0b359.png)

Après :
![screenshot_2014-10-13-23-59-31](https://cloud.githubusercontent.com/assets/320372/4620916/86a4a7fc-5324-11e4-8197-90ca9758bd80.png)

![screenshot_2014-10-13-23-59-57](https://cloud.githubusercontent.com/assets/320372/4620921/8c3ecbc0-5324-11e4-83be-ac7e8e3130ec.png)
