### PR TITLE
correction installation dépendances bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "afupbarometre",
   "version": "0.1.0",
   "devDependencies": {
-    "bower": "1.2.8",
+    "bower": "1.3.12",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
Lors du `bower install` on tombe sur cette erreur

```
Stack trace:
TypeError: Arguments to path.join must be strings
    at Object.exports.join (path.js:384:15)
    at GitHubResolver.GitResolver._cleanup (/home/guillaume/Developpement/barometre/node_modules/bower/lib/core/resolvers/GitResolver.js:185:26)
    at /home/guillaume/Developpement/barometre/node_modules/bower/lib/core/resolvers/GitResolver.js:74:25
    at Promise.apply (/home/guillaume/Developpement/barometre/node_modules/bower/node_modules/q/q.js:1122:26)
    at Promise.promise.promiseDispatch (/home/guillaume/Developpement/barometre/node_modules/bower/node_modules/q/q.js:752:41)
    at /home/guillaume/Developpement/barometre/node_modules/bower/node_modules/q/q.js:1337:14
    at flush (/home/guillaume/Developpement/barometre/node_modules/bower/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:343:11)
```

En utilisant la dernière version de bower, le problème n'apparait plus.