### PR TITLE
correction du menu sur mobile

### DIFF
--- a/src/Afup/BarometreBundle/Menu/MenuBuilder.php
+++ b/src/Afup/BarometreBundle/Menu/MenuBuilder.php
@@ -43,6 +43,7 @@ class MenuBuilder
     protected function getBaseMenu()
     {
         $menu = $this->factory->createItem('menu');
+        $menu->setChildrenAttribute('class', 'nav navbar-nav');
 
         $menu->addChild(
             'A propos du baromètre',
@@ -77,7 +78,6 @@ class MenuBuilder
         ]);
         $menu['Résultats détaillés']->setChildrenAttribute('class', 'dropdown-menu');
 
-        $menu->setChildrenAttribute('class', 'nav navbar-nav');
 
         $this->addReportsMenuItems($menu['Résultats détaillés']);
 


### PR DESCRIPTION
Les classes "nav navbar-nav" n'étaient pas ajoutées sur le menu mobile.
On les ajoute donc dans tous les cas et pas seulement sur desktop.

cf #182 