### PR TITLE
Fixed assets url if web root is not server root (#187)

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -55,3 +55,6 @@ knp_menu:
 
 afup_barometre:
     min_result: %min_result%
+
+grunt_hash_assets:
+    assets_base_path: %web_root%/assets

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -19,3 +19,5 @@ parameters:
     min_result:        5
 
     doctrine.server_version: "5.6"
+
+    web_root: ''


### PR DESCRIPTION
Cela fixe (en partie) le chargement des ressources lorsque la racine du site web n'est pas la racine du serveur (surtout en développement).

Cf ticket https://github.com/afup/barometre/issues/187