### PR TITLE
Fix Issue #102 switch min max

### DIFF
--- a/src/Afup/Barometre/Filter/SalaryFilter.php
+++ b/src/Afup/Barometre/Filter/SalaryFilter.php
@@ -35,6 +35,15 @@ class SalaryFilter implements FilterInterface
             return;
         }
 
+        //Switch min and max salary if user has inverted the fields
+        if (isset($values['salary']['min'])
+            && isset($values['salary']['max'])
+            && $values['salary']['max'] < $values['salary']['min']
+            ) {
+            list($values['salary']['min'], $values['salary']['max']) =
+                [$values['salary']['max'], $values['salary']['min']];
+        }
+
         if (isset($values['salary']['min'])) {
             $queryBuilder
                 ->andWhere('response.grossAnnualSalary >= :minSalary')
@@ -53,6 +62,11 @@ class SalaryFilter implements FilterInterface
      */
     public function convertValuesToLabels($value)
     {
+        //Switch min and max if user has inverted the fields
+        if (isset($value['min']) && isset($value['max']) && $value['max'] < $value['min']) {
+            list($value['max'], $value['min']) = [$value['min'], $value['max']];
+        }
+
         if (isset($value['min'])) {
             $value['min'] = '>= '.$value['min'];
         }

--- a/src/Afup/Barometre/Filter/SalaryFilter.php
+++ b/src/Afup/Barometre/Filter/SalaryFilter.php
@@ -53,11 +53,11 @@ class SalaryFilter implements FilterInterface
      */
     public function convertValuesToLabels($value)
     {
-        if (null !== $value['min']) {
+        if (isset($value['min'])) {
             $value['min'] = '>= '.$value['min'];
         }
 
-        if (null !== $value['max']) {
+        if (isset($value['max'])) {
             $value['max'] = '<= '.$value['max'];
         }
 

--- a/tests/unit/Afup/Barometre/Filter/SalaryFilter.php
+++ b/tests/unit/Afup/Barometre/Filter/SalaryFilter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Afup\Barometre\Filter\Tests\Units;
+
+use agallou\Departements\Collection;
+use atoum;
+
+
+class SalaryFilter extends atoum
+{
+    public function testConvertValuesToLabelDisplayOnlySettedValues()
+    {
+        $salaryFilter = new \Afup\Barometre\Filter\SalaryFilter();
+        $this
+            ->array($salaryFilter->convertValuesToLabels(['min' => 15000]))
+                ->isIdenticalTo(['min' => '>= 15000'])
+            ->array($salaryFilter->convertValuesToLabels(['max' => 15000]))
+                ->isIdenticalTo(['max' => '<= 15000'])
+            ->array($salaryFilter->convertValuesToLabels(['min' => 15000, 'max' => 20000]))
+                ->isIdenticalTo(['min' => '>= 15000', 'max' => '<= 20000'])
+        ;
+    }
+
+    public function testConvertValuesCanSwitchValueIfRequired()
+    {
+        $salaryFilter = new \Afup\Barometre\Filter\SalaryFilter();
+        $this
+            ->array($salaryFilter->convertValuesToLabels(['min' => 20000, 'max' => 15000]))
+            ->isIdenticalTo(['min' => '>= 15000', 'max' => '<= 20000'])
+        ;
+    }
+
+    public function testBuildQuerySetCorrectParameterForMinAndMaxInNormalCase()
+    {
+        $salaryFilter = new \Afup\Barometre\Filter\SalaryFilter();
+        $mockQueryBuilder = $this->getMockedQueryBuilder();
+        $salaryFilter->buildQuery($mockQueryBuilder, ['salary' => ['min' => 20000, 'max' => 25000]]);
+        $this
+            ->mock($mockQueryBuilder)
+                ->call('setParameter')
+                    ->withArguments('minSalary', 20000)->once()
+                    ->withArguments('maxSalary', 25000)->once()
+            ;
+    }
+
+    public function testBuildQuerySwitchParameterForMinAndMaxInverted()
+    {
+        $salaryFilter = new \Afup\Barometre\Filter\SalaryFilter();
+        $mockQueryBuilder = $this->getMockedQueryBuilder();
+        $salaryFilter->buildQuery($mockQueryBuilder, ['salary' => ['min' => 25000, 'max' => 20000]]);
+        $this
+            ->mock($mockQueryBuilder)
+                ->call('setParameter')
+                    ->withArguments('minSalary', 20000)->once()
+                    ->withArguments('maxSalary', 25000)->once()
+        ;
+    }
+
+    protected function getMockedQueryBuilder()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $mock = new \mock\Doctrine\DBAL\Query\QueryBuilder;
+        $this
+            ->calling($mock)->methodsMatching('/^./')->return = $mock;
+        return $mock;
+    }
+
+}


### PR DESCRIPTION
J'ai commité à part la suppression de quelques E_NOTICE, principalement parce qu'atoum rale quand il en croise.

Alors le probléme initial soulevé dans #102 n'est pas complétement résolu. Plutôt que d'empecher en front de saisir une valeur min supérieur à une valeur max (notamment parce que je ne suis pas un crac coté JS et que je ne sais pas s'il vaut mieux betement bloquer la saisie de ce que l'utilisateur est en train de saisir, ou bien adapter le second champs, ou bien faire autre chose), j'interverti les deux valeurs si nécessaire pour toujours avoir un salaire min < au salaire.