### PR TITLE
ajout de php 7 dans les version de php

### DIFF
--- a/src/Afup/BarometreBundle/Enums/PHPVersionEnums.php
+++ b/src/Afup/BarometreBundle/Enums/PHPVersionEnums.php
@@ -10,6 +10,7 @@ class PHPVersionEnums extends AbstractEnums
     const PHP_54 = 3;
     const PHP_55 = 4;
     const PHP_56 = 5;
+    const PHP_7 = 6;
 
     /**
      * @var array
@@ -21,6 +22,7 @@ class PHPVersionEnums extends AbstractEnums
         self::PHP_54 => 'PHP 5.4',
         self::PHP_55 => 'PHP 5.5',
         self::PHP_56 => 'PHP 5.6',
+        self::PHP_7 => 'PHP 7',
     );
 
     /**


### PR DESCRIPTION
(4 réponses dans le baromètre 2015, elles n'apparaitrons
pas dans la liste des versions, et un filtre sur cette version
n'affichera aucun tableau).