### PR TITLE
Ajout "agence web"  sur la libellé SSII

### DIFF
--- a/src/Afup/BarometreBundle/Enums/CompanyTypeEnums.php
+++ b/src/Afup/BarometreBundle/Enums/CompanyTypeEnums.php
@@ -16,7 +16,7 @@ class CompanyTypeEnums extends AbstractEnums
      */
     protected $choices = array(
         self::PRESSE_MEDIA => "Presse / média",
-        self::SSII         => "SSII / conseil",
+        self::SSII         => "SSII / agence web / conseil",
         self::AGENCE_COMM  => "Agence de communication",
         self::CLIENT_FINAL => "Service informatique d'un client final",
         self::STARTUP      => "Startup",


### PR DESCRIPTION
Beaucoup d'agences web ne se retrouvent pas dans le terme SSII et on préféré mettre "Autre", je propose juste de l'ajouter dans le libellé, à voir si on ne fait pas un nouveau type