### PR TITLE
Amélioration de la compatibilité de notre docker avec docker for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 .PHONY: vendors data_dirs
 
 CURRENT_UID=$(shell id -u)
-CURRENT_GID=$(shell id -g)
 
 init:
 	docker-compose run --rm cli /bin/bash -l -c "make vendors"
 	docker-compose run --rm cli /bin/bash -l -c "grunt"
 	docker-compose run --rm cli /bin/bash -l -c "php app/console doctrine:schema:update --force"
-	docker-compose run --rm cli /bin/bash -l -c "php app/console doctrine:fixtures:load --no-interaction --fixtures=src/Afup/BarometreBundle/DataTest/ORM/"
+	docker-compose run --rm cli /bin/bash -l -c "php -d "memory_limit=-1" app/console doctrine:fixtures:load --no-interaction --fixtures=src/Afup/BarometreBundle/DataTest/ORM/"
 
 vendors: node_modules vendor .vendors/bundler bower_components
 
@@ -28,7 +27,7 @@ node_modules:
 	bundle install --path .vendors/bundler
 
 bower_components:
-	./node_modules/bower/bin/bower install
+	./node_modules/bower/bin/bower install --allow-root
 
 app/config/parameters.yml:
 	cp app/config/parameters.yml.dist app/config/parameters.yml
@@ -40,7 +39,7 @@ docker-build: app/logs/.docker-build
 
 app/logs/.docker-build: docker-compose.yml docker-compose.override.yml $(shell find docker/dockerfiles -type f)
 	docker-compose rm --force
-	CURRENT_UID=$(CURRENT_UID) CURRENT_GID=$(CURRENT_GID) docker-compose build
+	CURRENT_UID=$(CURRENT_UID) docker-compose build
 	touch app/logs/.docker-build
 
 data_dirs: docker/data docker/data/composer

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: vendors data_dirs
 
-CURRENT_UID=$(shell id -u)
+CURRENT_UID ?= $(shell id -u)
 
 init:
 	docker-compose run --rm cli /bin/bash -l -c "make vendors"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Ce site a pour vocation de présenter les résultats de cette enquête en permet
 
 _Les ports utilisés peuvent être modifiés dans le fichier `docker-compose.override.yml`._
 
+### Problème connus
+
+Lors de l'installation du projet avec docker, nous utilisons l'id de l'utilisateurs courant pour palier les différents problèmes de droits,
+Avec docker-machine, l'id de l'utilisateurs courant ne correspond pas à celui de docker-machine,
+pour que cela fonctionne correctement il faut surcharger la variable d'envirronement CURRENT_UID avec la valeur 1000.
+
+exemple:
+
+```
+CURRENT_UID=1000 make docker-up
+```
 
 ## Installation manuelle
 

--- a/docker-compose.override.yml-dist
+++ b/docker-compose.override.yml-dist
@@ -1,4 +1,5 @@
 version: "2.1"
+
 services:
   db:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "2.1"
+
 services:
   db:
     image: mysql:5.5
@@ -15,7 +16,6 @@ services:
       context: ./docker/dockerfiles/web
       args:
         uid: "${CURRENT_UID:-1001}"
-        gid: "${CURRENT_GID:-1001}"
     volumes:
       - .:/var/www/html
     links:
@@ -26,11 +26,9 @@ services:
       context: ./docker/dockerfiles/cli
       args:
         uid: "${CURRENT_UID:-1001}"
-        gid: "${CURRENT_GID:-1001}"
     links:
       - db
     volumes:
       - .:/var/www/html
     command: "false"
-    user: localUser
     working_dir: /var/www/html

--- a/docker/dockerfiles/cli/Dockerfile
+++ b/docker/dockerfiles/cli/Dockerfile
@@ -29,9 +29,5 @@ RUN echo "date.timezone=Europe/Paris" >> "/usr/local/etc/php/php.ini"
 RUN echo "error_reporting = E_ALL" >> /usr/local/etc/php/php.ini
 
 ARG uid=1008
-ARG gid=1008
 
-RUN groupadd -g ${gid} localUser \
-    && useradd -u ${uid} -g ${gid} -m -s /bin/bash localUser
-
-RUN usermod -a -G www-data localUser
+RUN usermod -u ${uid} www-data

--- a/docker/dockerfiles/web/Dockerfile
+++ b/docker/dockerfiles/web/Dockerfile
@@ -8,18 +8,8 @@ RUN apt-get update && apt-get install -y libicu-dev build-essential
 RUN docker-php-ext-install intl
 RUN echo "Include sites-enabled/" >> /etc/apache2/apache2.conf
 
-
 ARG uid=1008
-ARG gid=1008
-RUN groupadd -g ${gid} localUser \
-    && useradd -u ${uid} -g ${gid} -m -s /bin/bash localUser
 
-RUN usermod -a -G www-data localUser
-
-RUN sed --in-place "s/User \${APACHE_RUN_USER}/User localUser/" /etc/apache2/apache2.conf
-RUN sed --in-place  "s/Group \${APACHE_RUN_GROUP}/Group localUser/" /etc/apache2/apache2.conf
+RUN usermod -u ${uid} www-data
 
 COPY apache.conf /etc/apache2/sites-enabled/000-default.conf
-
-
-


### PR DESCRIPTION
le gid par défaut sur mac (20), ne permet pas de créer un groupe dans l'image docker.

On n'utilise plus que le uid pour modifier celui utilisé par apache avec l'utiliser www-data