### PR TITLE
Corriger le filtrage sur les salaires

### DIFF
--- a/src/Afup/Barometre/Filter/SalaryFilter.php
+++ b/src/Afup/Barometre/Filter/SalaryFilter.php
@@ -67,15 +67,16 @@ class SalaryFilter implements FilterInterface
             list($value['max'], $value['min']) = [$value['min'], $value['max']];
         }
 
+        $labels = [];
         if (isset($value['min'])) {
-            $value['min'] = '>= '.$value['min'];
+            $labels['min'] = '>= '.$value['min'];
         }
 
         if (isset($value['max'])) {
-            $value['max'] = '<= '.$value['max'];
+            $labels['max'] = '<= '.$value['max'];
         }
 
-        return $value;
+        return $labels;
     }
 
     /**

--- a/src/Afup/Barometre/Form/Type/SalaryFilterType.php
+++ b/src/Afup/Barometre/Form/Type/SalaryFilterType.php
@@ -3,6 +3,7 @@
 namespace Afup\Barometre\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -16,8 +17,9 @@ class SalaryFilterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('min', 'number', ['required' => false])
-            ->add('max', 'number', ['required' => false]);
+            ->add('min', IntegerType::class, ['required' => false])
+            ->add('max', IntegerType::class, ['required' => false])
+        ;
     }
 
     /**

--- a/tests/unit/Afup/Barometre/Filter/SalaryFilter.php
+++ b/tests/unit/Afup/Barometre/Filter/SalaryFilter.php
@@ -18,6 +18,10 @@ class SalaryFilter extends atoum
                 ->isIdenticalTo(['max' => '<= 15000'])
             ->array($salaryFilter->convertValuesToLabels(['min' => 15000, 'max' => 20000]))
                 ->isIdenticalTo(['min' => '>= 15000', 'max' => '<= 20000'])
+            ->array($salaryFilter->convertValuesToLabels(['min' => 15000, 'max' => null]))
+                ->isIdenticalTo(['min' => '>= 15000'])
+            ->array($salaryFilter->convertValuesToLabels(['min' => null, 'max' => 20000]))
+                ->isIdenticalTo(['max' => '<= 20000'])
         ;
     }
 


### PR DESCRIPTION
Les valeurs saisies sont déjà vérifiées et filtrées mais aucune erreur n'est affichée sur l'IHM.
Décision : ajout simple d'une validation HTML5
Correction d'un bug dans l'affiche des labels

Voir issue #101 