### PR TITLE
Corriger les erreurs de code style

### DIFF
--- a/src/Afup/BarometreBundle/Controller/PressReviewController.php
+++ b/src/Afup/BarometreBundle/Controller/PressReviewController.php
@@ -36,7 +36,7 @@ class PressReviewController extends Controller
         krsort($reviewsByYear);
 
         foreach ($reviewsByYear as &$reviews) {
-            usort($reviews, function($reviewA, $reviewB) {
+            usort($reviews, function ($reviewA, $reviewB) {
                 return $reviewA['date'] < $reviewB['date'] ? 1 : -1;
             });
         }
@@ -49,6 +49,7 @@ class PressReviewController extends Controller
      */
     protected function getPressReviews()
     {
+        //@codingStandardsIgnoreStart
         return [
             [
                 'url' => 'http://www.clubic.com/pro/emploi-informatique/actualite-739143-afup-barometre-php-salaire-developpeur-secteur.html',
@@ -261,5 +262,6 @@ class PressReviewController extends Controller
                 'date' => '2017-12-14',
             ],
         ];
+        //@codingStandardsIgnoreEnd
     }
 }


### PR DESCRIPTION
En mettant en place les prehooks git, des erreurs se sont affichées sur le code style.

Le tableau contenant les revues de presse contient des urls trop longues pour le code style. Il faudrait sortir ce tableau dans un fichier de ressources ou en base de données et le charger dynamiquement.
En attendant, j'ai ajouter le fait d'ignorer le code style de cette méthode.

Deux questions :

- J'ai vu qu'il y avait un fichier .travis.yml => est-ce que l'intégration avec travis a déjà été faite auparavant ? Ca pourrait être bien que ça soit lancée à chaque PR je pense.
- Pour ce qui est du code style (discussion par rapport à la PR #283), utilisez-vous déjà des normes d'écriture autre que simplement PSR2 ? J'ai l'habitude d'utiliser les coding standard Symfony de M6Web (https://github.com/M6Web/Symfony2-coding-standard).