### PR TITLE
Ajouter le pourcentage de réponses dans les tableaux du rapport géographique

### DIFF
--- a/src/Afup/Barometre/Report/AbstractReport.php
+++ b/src/Afup/Barometre/Report/AbstractReport.php
@@ -110,4 +110,48 @@ abstract class AbstractReport implements ReportInterface
     {
         return $this->childReports = $childReports;
     }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    protected function addPercentResponse(array $data)
+    {
+        $totalResponseNumber = $this->calculateTotalResponseNumber($data);
+
+        if ($totalResponseNumber == 0) {
+            return array_map(
+                function ($response) use ($totalResponseNumber) {
+                    $response['percentResponse'] = 0;
+
+                    return $response;
+                },
+                $data
+            );
+        }
+
+        return array_map(
+            function ($response) use ($totalResponseNumber) {
+                $response['percentResponse'] = $response['nbResponse'] * 100 / $totalResponseNumber;
+
+                return $response;
+            },
+            $data
+        );
+    }
+
+    /**
+     * @param array $data
+     * @return integer mixed
+     */
+    private function calculateTotalResponseNumber(array $data)
+    {
+        return array_reduce(
+            $data,
+            function ($totalResponseNumber, $response) {
+                return $totalResponseNumber += $response['nbResponse'];
+            },
+            0
+        );
+    }
 }

--- a/src/Afup/Barometre/Report/CompanyCountyReport.php
+++ b/src/Afup/Barometre/Report/CompanyCountyReport.php
@@ -31,6 +31,8 @@ class CompanyCountyReport extends AbstractReport
             unset($row['totalAnnualSalary']);
             $this->data[] = $row;
         }
+
+        $this->data = $this->addPercentResponse($this->data);
     }
 
     /**
@@ -52,20 +54,20 @@ class CompanyCountyReport extends AbstractReport
     }
 
     /**
-     * @param arrya $data
+     * @param array $data
      *
      * @return array
      */
     protected function groupDataByRegion(array $data)
     {
         $preparedData = array();
-        $codesRegionsByCodesDeparatement = $this->getCodesRegionsByCodeDepartement();
+        $codesRegionsByCodesDepartment = $this->getCodesRegionsByCodeDepartement();
 
         foreach ($data as $row) {
-            if (!isset($codesRegionsByCodesDeparatement[$row['companyDepartment']])) {
+            if (!isset($codesRegionsByCodesDepartment[$row['companyDepartment']])) {
                 continue;
             }
-            $codeRegion = $codesRegionsByCodesDeparatement[$row['companyDepartment']];
+            $codeRegion = $codesRegionsByCodesDepartment[$row['companyDepartment']];
             if (!isset($preparedData[$codeRegion])) {
                 $preparedData[$codeRegion] = array(
                     'nbResponse' => 0,

--- a/src/Afup/Barometre/Report/CompanyDepartmentReport.php
+++ b/src/Afup/Barometre/Report/CompanyDepartmentReport.php
@@ -20,7 +20,7 @@ class CompanyDepartmentReport extends AbstractReport
             ->setParameter(':minResult', $this->minResult)
             ->addGroupBy('response.companyDepartment');
 
-        $this->data = $this->queryBuilder->execute()->fetchAll();
+        $this->data = $this->addPercentResponse($this->queryBuilder->execute()->fetchAll());
     }
 
     /**

--- a/src/Afup/BarometreBundle/Resources/translations/messages.fr.xliff
+++ b/src/Afup/BarometreBundle/Resources/translations/messages.fr.xliff
@@ -178,6 +178,10 @@
                 <source>report.view.response_number</source>
                 <target>Nombre de réponses</target>
             </trans-unit>
+            <trans-unit id="report.view.response_percent">
+                 <source>report.view.response_percent</source>
+                 <target>Pourcentage de réponses</target>
+            </trans-unit>
             <trans-unit id="report.view.company_size">
                 <source>report.view.company_size</source>
                 <target>Taille d'entreprise</target>

--- a/src/Afup/BarometreBundle/Resources/views/Report/company_county.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Report/company_county.html.twig
@@ -10,6 +10,7 @@
             <th>{{ "report.view.county_code" | trans }}</th>
             <th>{{ "report.view.county_label" | trans }}</th>
             <th>{{ "report.view.response_number" | trans }}</th>
+            <th>{{ "report.view.response_percent" | trans }}</th>
             <th>{{ "report.view.annual_salary" | trans }}</th>
         </tr>
     </thead>
@@ -19,6 +20,7 @@
                 <td>{{ row.companyDepartment }}</td>
                 <td>{{ row.companyDepartment|county_label }}</td>
                 <td>{{ row.nbResponse }}</td>
+                <td>{{ row.percentResponse|round(2) }}</td>
                 <td class="text-right">{{ row.annualSalary|round(-2)|number_format_decimal }}</td>
             </tr>
         {% endfor %}

--- a/src/Afup/BarometreBundle/Resources/views/Report/company_department.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Report/company_department.html.twig
@@ -10,6 +10,7 @@
             <th>{{ "report.view.department_code" | trans }}</th>
             <th>{{ "report.view.department_label" | trans }}</th>
             <th>{{ "report.view.response_number" | trans }}</th>
+            <th>{{ "report.view.response_percent" | trans }}</th>
             <th>{{ "report.view.annual_salary" | trans }}</th>
         </tr>
     </thead>
@@ -19,6 +20,7 @@
                 <td>{{ row.companyDepartment }}</td>
                 <td>{{ row.companyDepartment|department_label }}</td>
                 <td>{{ row.nbResponse }}</td>
+                <td>{{ row.percentResponse|round(2) }}</td>
                 <td class="text-right">{{ row.annualSalary|round(-2)|number_format_decimal }}</td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Je n'ai pas ajouté la fonction twig `|number_format_decimal` sur les pourcentages affichés afin que le tri se fasse correctement par la lib tablesorter (le tri ne fonctionne pas si le séparateur décimal est une `,`)
Link to issue : #289 