### PR TITLE
Corriger le code deprecated pour prévoir la montée de version de Symfony en 3.X

### DIFF
--- a/app/config/press_review.yml
+++ b/app/config/press_review.yml
@@ -18,7 +18,7 @@ parameters:
                 date: "2013-11-21"
             -
                 url: http://www.clubic.com/pro/emploi-informatique/actualite-602350-developpeur-php-salaire-metier-perspective-satisfaction-etude-afup.html
-                title: PHP: quels sont les salaires du secteur en France ?
+                title: "PHP: quels sont les salaires du secteur en France ?"
                 media_logo: clubic.png
                 date: "2013-11-21"
             -
@@ -128,7 +128,7 @@ parameters:
                 date: "2016-01-13"
             -
                 url: http://www.toolinux.com/Developpeurs-le-barometre-des
-                title: Développeurs: le baromètre des salaires 2015 est connu
+                title: "Développeurs: le baromètre des salaires 2015 est connu"
                 media_logo: toolinux.png
                 date: "2016-01-18"
             -
@@ -158,7 +158,7 @@ parameters:
                 date: "2016-10-28"
             -
                 url: http://www.silicon.fr/salaires-developpeurs-php-2016-afup-162024.html
-                title: Salaires: des disparités entre développeurs PHP en 2016
+                title: "Salaires: des disparités entre développeurs PHP en 2016"
                 media_logo: silicon.png
                 date: "2016-11-07"
         2017:

--- a/composer.lock
+++ b/composer.lock
@@ -1323,36 +1323,38 @@
         },
         {
             "name": "knplabs/knp-menu",
-            "version": "v2.1.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/KnpMenu.git",
-                "reference": "c6ad49933babd06a27b2f962a3469601ec9038b8"
+                "reference": "b6aade272c345b6fbd07fce5929a761cba0909b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpMenu/zipball/c6ad49933babd06a27b2f962a3469601ec9038b8",
-                "reference": "c6ad49933babd06a27b2f962a3469601ec9038b8",
+                "url": "https://api.github.com/repos/KnpLabs/KnpMenu/zipball/b6aade272c345b6fbd07fce5929a761cba0909b8",
+                "reference": "b6aade272c345b6fbd07fce5929a761cba0909b8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "twig/twig": "<1.40|>=2,<2.9"
             },
             "require-dev": {
-                "pimple/pimple": "~1.0",
-                "silex/silex": "~1.0",
-                "symfony/phpunit-bridge": "~2.7",
-                "twig/twig": "~1.16|~2.0"
+                "psr/container": "^1.0",
+                "symfony/http-foundation": "~2.4|~3.0|^4.0",
+                "symfony/phpunit-bridge": "~3.3|^4.0",
+                "symfony/routing": "~2.3|~3.0|^4.0",
+                "twig/twig": "^1.40|^2.9"
             },
             "suggest": {
-                "pimple/pimple": "for the built-in implementations of the menu provider and renderer provider",
-                "silex/silex": "for the integration with your silex application",
                 "twig/twig": "for the TwigRenderer and the integration with your templates"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1366,12 +1368,12 @@
             ],
             "authors": [
                 {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
+                    "name": "KnpLabs",
+                    "homepage": "https://knplabs.com"
                 },
                 {
-                    "name": "Knplabs",
-                    "homepage": "http://knplabs.com"
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
                 },
                 {
                     "name": "Symfony Community",
@@ -1379,44 +1381,46 @@
                 }
             ],
             "description": "An object oriented menu library",
-            "homepage": "http://knplabs.com",
+            "homepage": "https://knplabs.com",
             "keywords": [
                 "menu",
                 "tree"
             ],
-            "time": "2015-09-20T08:23:47+00:00"
+            "time": "2019-09-02T10:16:14+00:00"
         },
         {
             "name": "knplabs/knp-menu-bundle",
-            "version": "v2.1.0",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/KnpMenuBundle.git",
-                "reference": "2246a70109bdd313a105d2a7ef464a763aacf0cd"
+                "reference": "267027582a1f1e355276f796f8da0e9f82026bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpMenuBundle/zipball/2246a70109bdd313a105d2a7ef464a763aacf0cd",
-                "reference": "2246a70109bdd313a105d2a7ef464a763aacf0cd",
+                "url": "https://api.github.com/repos/KnpLabs/KnpMenuBundle/zipball/267027582a1f1e355276f796f8da0e9f82026bf1",
+                "reference": "267027582a1f1e355276f796f8da0e9f82026bf1",
                 "shasum": ""
             },
             "require": {
-                "knplabs/knp-menu": "~2.1",
-                "symfony/framework-bundle": "~2.3"
+                "knplabs/knp-menu": "~2.3",
+                "php": "^5.6 || ^7",
+                "symfony/framework-bundle": "~2.7|~3.0 | ^4.0"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.4",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/expression-language": "~2.7|~3.0 | ^4.0",
+                "symfony/phpunit-bridge": "^3.3 | ^4.0",
+                "symfony/templating": "~2.7|~3.0 | ^4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Knp\\Bundle\\MenuBundle\\": ""
+                    "Knp\\Bundle\\MenuBundle\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1441,7 +1445,7 @@
             "keywords": [
                 "menu"
             ],
-            "time": "2015-09-28T15:23:54+00:00"
+            "time": "2019-06-17T12:58:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2710,16 +2714,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.42.4",
+            "version": "v1.42.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "e587180584c3d2d6cb864a0454e777bb6dcb6152"
+                "reference": "87b2ea9d8f6fd014d0621ca089bb1b3769ea3f8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e587180584c3d2d6cb864a0454e777bb6dcb6152",
-                "reference": "e587180584c3d2d6cb864a0454e777bb6dcb6152",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/87b2ea9d8f6fd014d0621ca089bb1b3769ea3f8e",
+                "reference": "87b2ea9d8f6fd014d0621ca089bb1b3769ea3f8e",
                 "shasum": ""
             },
             "require": {
@@ -2728,8 +2732,7 @@
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/debug": "^3.4|^4.2",
-                "symfony/phpunit-bridge": "^4.4@dev|^5.0"
+                "symfony/phpunit-bridge": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
@@ -2758,7 +2761,6 @@
                 },
                 {
                     "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
                     "role": "Contributors"
                 },
                 {
@@ -2772,7 +2774,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-11-11T16:49:32+00:00"
+            "time": "2020-02-11T05:59:23+00:00"
         }
     ],
     "packages-dev": [
@@ -2936,6 +2938,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
+            "abandoned": "symfony/maker-bundle",
             "time": "2015-12-08T18:08:03+00:00"
         },
         {

--- a/src/Afup/Barometre/Filter/CampaignFilter.php
+++ b/src/Afup/Barometre/Filter/CampaignFilter.php
@@ -4,6 +4,7 @@ namespace Afup\Barometre\Filter;
 
 use Afup\BarometreBundle\Entity\Campaign;
 use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Doctrine\DBAL\Query\QueryBuilder;
 
@@ -14,7 +15,7 @@ class CampaignFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), 'entity', [
+        $builder->add($this->getName(), EntityType::class, [
             'label'    => 'filter.campaign',
             'class'    => 'Afup\BarometreBundle\Entity\Campaign',
             'attr'     => ['class' => 'select2'],

--- a/src/Afup/Barometre/Filter/CertificationFilter.php
+++ b/src/Afup/Barometre/Filter/CertificationFilter.php
@@ -4,6 +4,7 @@ namespace Afup\Barometre\Filter;
 
 use Afup\BarometreBundle\Entity\Certification;
 use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Doctrine\DBAL\Query\QueryBuilder;
 
@@ -14,7 +15,7 @@ class CertificationFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), 'entity', [
+        $builder->add($this->getName(), EntityType::class, [
             'label'    => 'filter.certification',
             'class'    => 'Afup\BarometreBundle\Entity\Certification',
             'attr'     => ['class' => 'select2'],

--- a/src/Afup/Barometre/Filter/CompanySizeFilter.php
+++ b/src/Afup/Barometre/Filter/CompanySizeFilter.php
@@ -28,9 +28,9 @@ class CompanySizeFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.company_size',
-            'choices'  => $this->companySizes->getChoices()
+            'choices'  => array_flip($this->companySizes->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/CompanyTypeFilter.php
+++ b/src/Afup/Barometre/Filter/CompanyTypeFilter.php
@@ -28,9 +28,9 @@ class CompanyTypeFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.company_type',
-            'choices'  => $this->companyTypes->getChoices()
+            'choices'  => array_flip($this->companyTypes->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/DepartmentFilter.php
+++ b/src/Afup/Barometre/Filter/DepartmentFilter.php
@@ -20,9 +20,9 @@ class DepartmentFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.department',
-            'choices'  => $this->getChoices(),
+            'choices'  => array_flip($this->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/DistrictFilter.php
+++ b/src/Afup/Barometre/Filter/DistrictFilter.php
@@ -5,7 +5,6 @@ namespace Afup\Barometre\Filter;
 use Symfony\Component\Form\FormBuilderInterface;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Connection;
-use agallou\Departements\Collection as Departments;
 use agallou\Regions\Collection2016 as Regions;
 
 use Afup\Barometre\Form\Type\Select2MultipleFilterType;
@@ -17,9 +16,9 @@ class DistrictFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.district',
-            'choices'  => $this->getChoices(),
+            'choices'  => array_flip($this->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/ExperienceFilter.php
+++ b/src/Afup/Barometre/Filter/ExperienceFilter.php
@@ -28,9 +28,9 @@ class ExperienceFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.experience',
-            'choices'  => $this->experience->getChoices()
+            'choices'  => array_flip($this->experience->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/GenderFilter.php
+++ b/src/Afup/Barometre/Filter/GenderFilter.php
@@ -65,9 +65,9 @@ class GenderFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
                 'label'   => 'filter.gender',
-                'choices' => $this->gender->getChoices(),
+                'choices' => array_flip($this->gender->getChoices()),
             ]);
     }
 

--- a/src/Afup/Barometre/Filter/JobTitleFilter.php
+++ b/src/Afup/Barometre/Filter/JobTitleFilter.php
@@ -29,9 +29,9 @@ class JobTitleFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'   => 'filter.job_title',
-            'choices' => $this->jobTitles->getChoices(),
+            'choices' => array_flip($this->jobTitles->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/MeetupParticipationFilter.php
+++ b/src/Afup/Barometre/Filter/MeetupParticipationFilter.php
@@ -27,9 +27,9 @@ class MeetupParticipationFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.meetup_participation',
-            'choices'  => $this->meetupParticipationEnums->getChoices()
+            'choices'  => array_flip($this->meetupParticipationEnums->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/PHPVersionFilter.php
+++ b/src/Afup/Barometre/Filter/PHPVersionFilter.php
@@ -28,9 +28,9 @@ class PHPVersionFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.php_version',
-            'choices'  => $this->phpVersions->getChoices()
+            'choices'  => array_flip($this->phpVersions->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/RemoteUsageFilter.php
+++ b/src/Afup/Barometre/Filter/RemoteUsageFilter.php
@@ -27,9 +27,9 @@ class RemoteUsageFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.remote_work',
-            'choices'  => $this->remoteUsageEnums->getChoices()
+            'choices'  => array_flip($this->remoteUsageEnums->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/SalaryFilter.php
+++ b/src/Afup/Barometre/Filter/SalaryFilter.php
@@ -17,13 +17,9 @@ class SalaryFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add(
-            'salary',
-            new SalaryFilterType(),
-            [
+        $builder->add('salary', SalaryFilterType::class, [
                 'label' => 'filter.salary',
-            ]
-        );
+        ]);
     }
 
     /**

--- a/src/Afup/Barometre/Filter/SalarySatisfactionFilter.php
+++ b/src/Afup/Barometre/Filter/SalarySatisfactionFilter.php
@@ -28,9 +28,9 @@ class SalarySatisfactionFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'    => 'filter.salary_satisfaction',
-            'choices'  => $this->salarySatisfaction->getChoices()
+            'choices'  => array_flip($this->salarySatisfaction->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Filter/SpecialityFilter.php
+++ b/src/Afup/Barometre/Filter/SpecialityFilter.php
@@ -4,6 +4,7 @@ namespace Afup\Barometre\Filter;
 
 use Afup\BarometreBundle\Entity\Speciality;
 use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Doctrine\DBAL\Query\QueryBuilder;
 
@@ -14,7 +15,7 @@ class SpecialityFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), 'entity', [
+        $builder->add($this->getName(), EntityType::class, [
             'label'    => 'filter.speciality',
             'class'    => 'Afup\BarometreBundle\Entity\Speciality',
             'attr'     => ['class' => 'select2'],

--- a/src/Afup/Barometre/Filter/StatusFilter.php
+++ b/src/Afup/Barometre/Filter/StatusFilter.php
@@ -29,9 +29,9 @@ class StatusFilter implements FilterInterface
      */
     public function buildForm(FormBuilderInterface $builder)
     {
-        $builder->add($this->getName(), new Select2MultipleFilterType(), [
+        $builder->add($this->getName(), Select2MultipleFilterType::class, [
             'label'   => 'filter.status',
-            'choices' => $this->status->getChoices(),
+            'choices' => array_flip($this->status->getChoices()),
         ]);
     }
 

--- a/src/Afup/Barometre/Form/Type/FilterType.php
+++ b/src/Afup/Barometre/Form/Type/FilterType.php
@@ -2,6 +2,7 @@
 
 namespace Afup\Barometre\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -35,7 +36,7 @@ class FilterType extends AbstractType
 
         $builder
             ->setMethod('GET')
-            ->add('submit', 'submit', ['label' => 'filter.submit']);
+            ->add('submit', SubmitType::class, ['label' => 'filter.submit']);
     }
 
     /**
@@ -49,7 +50,7 @@ class FilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'filter';
     }

--- a/src/Afup/Barometre/Form/Type/SalaryFilterType.php
+++ b/src/Afup/Barometre/Form/Type/SalaryFilterType.php
@@ -25,7 +25,7 @@ class SalaryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'salary';
     }

--- a/src/Afup/Barometre/Form/Type/Select2MultipleFilterType.php
+++ b/src/Afup/Barometre/Form/Type/Select2MultipleFilterType.php
@@ -2,6 +2,7 @@
 
 namespace Afup\Barometre\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -17,6 +18,7 @@ class Select2MultipleFilterType extends AbstractType
     {
         $resolver->setDefaults(
             [
+                'choices_as_values' => true,
                 'multiple' => true,
                 'required' => false,
                 'attr'     => [
@@ -30,7 +32,7 @@ class Select2MultipleFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'select2_multiple_filter';
     }
@@ -40,6 +42,6 @@ class Select2MultipleFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return ChoiceType::class;
     }
 }

--- a/src/Afup/BarometreBundle/DataFixtures/ORM/FixturesLoader.php
+++ b/src/Afup/BarometreBundle/DataFixtures/ORM/FixturesLoader.php
@@ -5,11 +5,14 @@ namespace Afup\BarometreBundle\DataFixtures\ORM;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Nelmio\Alice\Fixtures;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-class FixturesLoader extends ContainerAware implements FixtureInterface
+class FixturesLoader implements FixtureInterface, ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Afup/BarometreBundle/DataTest/ORM/FixturesLoader.php
+++ b/src/Afup/BarometreBundle/DataTest/ORM/FixturesLoader.php
@@ -6,11 +6,14 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Nelmio\Alice\Fixtures;
 use Afup\BarometreBundle\DataTest\EnumsProvider;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-class FixturesLoader extends ContainerAware implements FixtureInterface
+class FixturesLoader implements FixtureInterface, ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Afup/BarometreBundle/Resources/config/services.xml
+++ b/src/Afup/BarometreBundle/Resources/config/services.xml
@@ -92,12 +92,12 @@
 
         <service id="afup.barometre.type.filter" class="Afup\Barometre\Form\Type\FilterType">
             <argument type="service" id="afup.barometre.filter_collection" />
-            <tag name="form.type" alias="filter" />
+            <tag name="form.type" />
         </service>
 
         <service id="afup.barometre.filter_form" class="Symfony\Component\Form\FormInterface" shared="false">
             <factory service="form.factory" method="create" />
-            <argument>filter</argument>
+            <argument>Afup\Barometre\Form\Type\FilterType</argument>
         </service>
 
         <service id="afup.barometre.report_collection" class="Afup\Barometre\Report\ReportCollection">

--- a/src/Afup/BarometreBundle/Resources/views/Default/index.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/Default/index.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row">
         <div class="col-md-9">
-            {% render(controller('AfupBarometreBundle:Report:index', {reportName: report_name })) %}
+            {{ render(controller('AfupBarometreBundle:Report:index', {reportName: report_name })) }}
         </div>
         <div class="col-md-3">
             <h1>Filtres</h1>

--- a/src/Afup/BarometreBundle/Twig/Enums.php
+++ b/src/Afup/BarometreBundle/Twig/Enums.php
@@ -43,12 +43,4 @@ class Enums extends \Twig_Extension
         }
         return $choices[$enumId];
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'afup_barometre_twig_enums';
-    }
 }

--- a/src/Afup/BarometreBundle/Twig/Extension/CountyExtension.php
+++ b/src/Afup/BarometreBundle/Twig/Extension/CountyExtension.php
@@ -44,12 +44,4 @@ class CountyExtension extends \Twig_Extension
             return $this->translator->trans('report.company_county.unknown');
         }
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'region';
-    }
 }

--- a/src/Afup/BarometreBundle/Twig/Extension/DepartmentExtension.php
+++ b/src/Afup/BarometreBundle/Twig/Extension/DepartmentExtension.php
@@ -44,12 +44,4 @@ class DepartmentExtension extends \Twig_Extension
             return $this->translator->trans('report.company_departement.unknown');
         }
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'department';
-    }
 }


### PR DESCRIPTION
Maintenant que les résultats sont publiés, j'en profite pour reprendre par petit bout le travail effectué dans la PR https://github.com/afup/barometre/pull/292

Je préfère faire par petite évolution afin d'éviter de tout révolutionner d'un coup et d'avancer petit à petit.

Première PR donc pour corriger les deprecated pour pouvoir passer ensuite en Symfony 3.X


