### PR TITLE
Ajouter Clever Cloud comme notre hébergeur

### DIFF
--- a/src/Afup/BarometreBundle/Resources/views/layout.html.twig
+++ b/src/Afup/BarometreBundle/Resources/views/layout.html.twig
@@ -55,6 +55,7 @@
     <footer class="page-footer">
         <div class="content">
             <p>Baromètre <a href="http://www.afup.org" target="_blank">AFUP</a> et <a href="https://www.journaldunet.com/" target="_blank"> le JDN</a> {{ "now"|date("Y") }}</p>
+            <p>Hébergé sur <a href="https://www.clever-cloud.com" target="_blank" title="Clever Cloud">Clever Cloud</a></p>
             <p><a href="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">Creative Commons  BY-NC-ND</a></p>
         </div>
     </footer>


### PR DESCRIPTION
Comme demandé lors du démarrage de la migration, j'ai rajouté l'information comme quoi le baromètre était hébergé sur Clever Cloud.

N'hésitez pas si vous avez des remarques.

![image](https://user-images.githubusercontent.com/15214050/149018577-c4b48124-0afa-4f1c-8e9b-adb4e7a92eda.png)
