### PR TITLE
résultats 2024 : on passe les résultats détaillés à droite

### DIFF
--- a/templates/Campaign/report2024.html.twig
+++ b/templates/Campaign/report2024.html.twig
@@ -115,8 +115,7 @@
 
             <h3>AFUP</h3>
             <p>L'<a href="http://www.afup.org" title="Association Française des Utilisateurs de PHP">AFUP</a>, Association Française des Utilisateurs de PHP, est une association loi 1901, qui a pour objectif principal de promouvoir le langage PHP auprès des professionnel·le·s et de participer à son développement. Elle organise de nombreux événements tout au long de l'année, notamment le Forum PHP et les AFUP Day, elle diffuse et partage les connaissances auprès des utilisateurs et utilisatrices de PHP, et participe à la valorisation des développeurs et développeuses PHP sur le marché du travail.</p>
-
-
+        </div>
         <div class="col-md-4">
             <h1>Résultats détaillés</h1>
 
@@ -124,6 +123,5 @@
                 {% block menu_reports knp_menu_render('reports_menu', {}, 'reports') %}
             </div>
         </div>
-
     </div>
 {% endblock %}


### PR DESCRIPTION
Les liens vers les résultats détaillés étaient en bas au lieu d'être à droite, cela car ils étaient contenus dans le col-md-8 au lieu d'être eu même niveau.

avant:
![Screenshot 2024-11-04 at 23-09-33 Résultats de la campagne 2024](https://github.com/user-attachments/assets/486a30c4-3c17-4258-9176-3ef002714003)

après:
![Screenshot 2024-11-04 at 23-09-24 Résultats de la campagne 2024](https://github.com/user-attachments/assets/383b2fdd-b900-4630-9444-ea8e9774337f)

