### PR TITLE
fermeture campagne 2026

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,13 +3,15 @@ afup_barometre_homepage:
   methods: GET
   controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
   defaults:
-    path: /campaign/2026
+    path: /about
     permanent: false
 
 afup_barometre_form:
   path: /campaign/2026
   methods: GET
-  controller: App\Controller\CampaignController::formAction
+  controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
+  defaults:
+    path: /about
 
 controllers:
   resource:

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -41,14 +41,6 @@ class MenuBuilder
         $menu->setChildrenAttribute('class', 'nav navbar-nav');
 
         $menu->addChild(
-            'menu.survey',
-            [
-                'route' => 'afup_barometre_form',
-                'routeAbsolute' => UrlGeneratorInterface::ABSOLUTE_URL,
-            ]
-        );
-
-        $menu->addChild(
             'menu.result2025',
             [
                 'route' => 'afup_barometre_campaign',


### PR DESCRIPTION
## Summary
- Redirige la page d'accueil (`/`) vers `/about` au lieu de `/campaign/2026`
- Redirige `/campaign/2026` vers `/about` (le formulaire n'est plus accessible)
- Retire le lien "Participer à l'enquête" du menu de navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)